### PR TITLE
Registering methods early

### DIFF
--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -30,6 +30,8 @@ class SDK extends Events {
         if (!conf.token && (!conf.username || !conf.password) && !conf.assertion) {
             throw new Error('missing token or user/password or assertion params');
         }
+        this.registerRequests(CONST.REQUESTS);
+        
         this.refreshSessionInterval = conf.refreshSessionInterval || (60000 * 10);//10 min
         this.conf = conf;
         async.waterfall([
@@ -85,7 +87,6 @@ class SDK extends Events {
         this.requestTimeout = options.requestTimeout || 10000;
 
         this.errorCheckInterval = options.errorCheckInterval || 1000;
-        this.registerRequests(CONST.REQUESTS);
 
         this.transport = new Transport(options);
         this.transport.on('message', (message) => this._handleMessage(message));


### PR DESCRIPTION
Rather than waiting for first initialization, have the methods available on the object from the get-go.