### PR TITLE
Pass the configuration to new WebSocket to allow usage of custom http…

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -28,7 +28,7 @@ class Transport extends Events {
     }
 
     _connect() {
-        this.ws = new WebSocket(connectionDetails.wsPath(this.configuration));
+        this.ws = new WebSocket(connectionDetails.wsPath(this.configuration), this.configuration);
 
         this.ws.on('open', () => {
             this.emit('open');


### PR DESCRIPTION
… agents (proxy)

Fixes issue #36 

In order to pass an http/https agent to the sdk, add an agent member to the configuration object passed to the AgentSDK constructor.
