### PR TITLE
Exposing Transformer and Adding it to Constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Agent = require('./lib/AgentSDK');
-const Transformer = require('./Transformer');
+const Transformer = require('./lib/Transformer');
 
 module.exports = {
     Agent,

--- a/index.js
+++ b/index.js
@@ -1,7 +1,9 @@
 'use strict';
 
 const Agent = require('./lib/AgentSDK');
+const Transformer = require('./Transformer');
 
 module.exports = {
-    Agent
+    Agent,
+    Transformer
 };

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -57,6 +57,7 @@ class SDK extends Events {
             throw new Error('missing token or user/password or assertion or appKey/secret/accessToken/accessTokenSecret params');
         }
         this.registerRequests(CONST.REQUESTS);
+        this.transformer = conf.transformer ? conf.transformer : Transformer;
 
         this.refreshSessionInterval = conf.refreshSessionInterval || (60000 * 10);//10 min
         this.conf = conf;
@@ -141,9 +142,9 @@ class SDK extends Events {
             metadata = void 0;
         }
 
-        if (Transformer[type]) {
+        if (this.transformer[type]) {
             // body = Transformer[type](body);
-            ({body, type, headers, metadata} = Transformer[type]({body, type, headers, metadata}, this));
+            ({body, type, headers, metadata} = this.transformer[type]({body, type, headers, metadata}, this));
 
         }
 
@@ -295,8 +296,8 @@ class SDK extends Events {
 
     _handleNotification(msg) {
         if (msg && msg.type) {
-            if (Transformer[msg.type]) {
-                msg = Transformer[msg.type](msg, this);
+            if (this.transformer[msg.type]) {
+                msg = this.transformer[msg.type](msg, this);
             }
             this.emit(msg.type, msg.body);
         }
@@ -305,8 +306,8 @@ class SDK extends Events {
 
     _handleResponse(msg) {
         if (msg && msg.type) {
-            if (Transformer[msg.type]) {
-                msg = Transformer[msg.type](msg, this);
+            if (this.transformer[msg.type]) {
+                msg = this.transformer[msg.type](msg, this);
             }
             this.emit(msg.type, msg.body, msg.reqId);
         }


### PR DESCRIPTION
- this allows the ability to override the response handlers. 

```
const Agent = require('node-agent-sdk').Agent;
let Transformer = require('node-agent-sdk').Transformer;
 
Transformer['.ams.userprofile.GetUserProfile$Response'] = (msg) => {
  //add own code
  return msg;
});
 
const agent = new Agent({
    accountId: process.env.LP_ACCOUNT,
    username: process.env.LP_USER,
    password: process.env.LP_PASS
    transformer: Transformer
});
```