### PR TITLE
Updating README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ To run the [greeting bot example][1]:
 - Run:
 
    ```sh
-   LP_ACCOUNT=1234567 LP_USER=BotUserName LP_PASSWORD=b0tpa55word node examples/greeting-bot/greeting-bot.js
+   LP_ACCOUNT=1234567 LP_USER=BotUserName LP_PASS=b0tpa55word node examples/greeting-bot/greeting-bot.js
    ```
    
 ## Agent Bot
@@ -44,7 +44,7 @@ To run the [agent bot example][2]
 - Run:
 
     ```sh
-   LP_ACCOUNT=1234567 LP_USER=BotUserName LP_PASSWORD=b0tpa55word node examples/agent-bot/main.js
+   LP_ACCOUNT=1234567 LP_USER=BotUserName LP_PASS=b0tpa55word node examples/agent-bot/main.js
     ```
    
 ## Bot Cluster


### PR DESCRIPTION
Params need to be LP_PASS instead of LP_PASSWORD when using command 
LP_ACCOUNT=1234567 LP_USER=BotUserName LP_PASS=b0tpa55word node examples/greeting-bot/greeting-bot.js
 if we use LP_PASSWORD it doesn't get authenticated and gives below error.
/home/ubuntu/node-agent-sdk/lib/AgentSDK.js:56
            throw new Error('missing token or user/password or assertion or appKey/secret/accessToken/accessTokenSecret params');
            ^

Error: missing token or user/password or assertion or appKey/secret/accessToken/accessTokenSecret params