### PR TITLE
Unhandled Exception Fix

### DIFF
--- a/lib/ExternalServices.js
+++ b/lib/ExternalServices.js
@@ -54,7 +54,7 @@ function refreshSession(options, callback) {
         json: true
     }, (err, response, body) => {
         let authError;
-        if (response.statusCode && response.statusCode === 401) {
+        if (response && response.statusCode && response.statusCode === 401) {
             authError = new SDKError('session unauthorized', 401);
         }
         callback(err || authError, body);


### PR DESCRIPTION
Bugfix for bug described in case 00795400.  Some sort of connection issue resulted in the client's bot crashing when the refreshSession request returned no response:

> Oct 27 12:28:37  TypeError: Cannot read property 'statusCode' of undefined
> Oct 27 12:28:37  /home/vcap/app/node_modules/node-agent-sdk/lib/ExternalServices.js:96
> Oct 27 12:28:37     at Request.request.post [as _callback] (/home/vcap/app/node_modules/node-agent-sdk/lib/ExternalServices.js:96:22)
> Oct 27 12:28:37         if (response.statusCode && response.statusCode === 401) {
> Oct 27 12:28:37                      ^
> Oct 27 12:28:37     at Request.onRequestError (/home/vcap/app/node_modules/request/request.js:881:8)
> Oct 27 12:28:37     at self.callback (/home/vcap/app/node_modules/request/request.js:185:22)
> Oct 27 12:28:37     at emitOne (events.js:116:13)
> Oct 27 12:28:37     at Request.emit (events.js:211:7)
> Oct 27 12:28:37     at emitOne (events.js:116:13)
> Oct 27 12:28:37     at ClientRequest.emit (events.js:211:7)
> Oct 27 12:28:37     at emitOne (events.js:116:13)
> Oct 27 12:28:37     at TLSSocket.socketErrorListener (_http_client.js:387:9)
> Oct 27 12:28:37     at TLSSocket.emit (events.js:211:7)