### PR TITLE
Handle PDD API Deleted SDEs

### DIFF
--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -79,22 +79,26 @@ module.exports = {
         let privateData = msg.body.privateData || {};
         let claims = msg.body.claims || {};
         if (claims && claims.lp_sdes) {
-            claims.lp_sdes.forEach(sde => {
-                sde.acr = msg.body.acr;
-                sde.iss = claims.iss;
-                SDEs.push(sde);
-            });
+            if (typeof claims.lp_sdes === 'string') {
+                SDEs.push({type: 'other', info: claims.lp_sdes})
+            } else {
+                claims.lp_sdes.forEach(sde => {
+                    sde.acr = msg.body.acr;
+                    sde.iss = claims.iss;
+                    SDEs.push(sde);
+                });
+            }
         }
         if (authData && authData.lp_sdes) {
-            authData.lp_sdes.forEach(sde => {
-                sde.auth = {};
-                SDEs.push(sde);
-            });
+            if (typeof authData.lp_sdes === 'string') {
+                SDEs.push({type: 'other', info: authData.lp_sdes})
+            } else {
+                authData.lp_sdes.forEach(sde => {
+                    sde.auth = {};
+                    SDEs.push(sde);
+                });
+            }
         }
-        let ctmrinfo = {
-            type: 'ctmrinfo',
-            info: {}
-        };
         if (privateData.mobileNum) {
             ctmrinfo.info.imei = privateData.mobileNum;
         }


### PR DESCRIPTION
When SDEs are deleted with the PDD API the array is replaced with '*** LP deleted data ***' which was causing an unhandled exception.