### PR TITLE
Removing firstConversation from deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1238,9 +1238,6 @@ agent.on('cqm.ExConversationChangeNotification', body => {
 });
 ```
 
-##### ExConversationChangeNotification firstConversation - *deprecated*
-In the `cqm.ExConversationChangeNotification` the field `firstConversation` is deprecated
-
 ### Further documentation
 
 - [LivePerson messaging API][1]


### PR DESCRIPTION
firstConversation attribute is not deprecated in the current UMS version and this warning was misleading since we can offer no replacement method