### PR TITLE
fix typo renamed `timoutId` to `timeoutId`

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -37,12 +37,12 @@ class Transport extends Events {
 
         this.ws.on('close', (code, reason) => {
             this.emit('close', code, reason);
-            clearTimeout(this.timoutId);
+            clearTimeout(this.timeoutId);
         });
 
         this.ws.on('error', err => {
             this.emit('error', err);
-            clearTimeout(this.timoutId);
+            clearTimeout(this.timeoutId);
         });
 
         this.ws.on('message', (data, flags) => {
@@ -59,7 +59,7 @@ class Transport extends Events {
 
     ping() {
         this.ws.ping();
-        this.timoutId = setTimeout(() => {
+        this.timeoutId = setTimeout(() => {
             this.ping();
         }, this.pingInterval);
     }
@@ -75,7 +75,7 @@ class Transport extends Events {
     }
 
     close() {
-        clearTimeout(this.timoutId);
+        clearTimeout(this.timeoutId);
         this.ws.terminate();
         this.ws = null;
     }


### PR DESCRIPTION
Discovered this when working with the `node-agent-sdk` - pretty sure this isn't intentional.