### PR TITLE
Bugfix missingprop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 
 ## Directory-based project format:
 .idea/
+.vscode/
 # if you remove the above rule, at least ignore the following:
 
 # User-specific stuff:

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -35,8 +35,8 @@ module.exports = {
                         }
 
                         // in case in the dialog there more paricipants than in the conversation
-                        let participantsPId = conversationDetails.participantsPId[p.role][roles[p.role]];
-                        p.id = participantsPId ? participantsPId : p.id;
+                        const participantsProp = Object.prototype.hasOwnProperty.call(conversationDetails.participantsPId, p.role);
+                        p.id = participantsProp ? conversationDetails.participantsPId[p.role][roles[p.role]] : p.id;
                         roles[p.role]++;
                     });
                 });


### PR DESCRIPTION
**Issue:**
When participantsPId did not contain the specific role property, the bot would crash at line 38 trying to assign to the id property inside p.

**Resolution:**
Check if prop exists and assign accordingly.
