### PR TITLE
New Exception when a Notification/Response contains wrong JSON.

### DIFF
--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -9,6 +9,7 @@ const async = require('async');
 const external = require('./ExternalServices');
 const Transformer = require('./Transformer');
 const SDKError = require('./error/SDKError');
+const ParseError = require('./error/ParseError');
 const CSDSClient = require('./CSDSClient');
 
 /**
@@ -304,7 +305,11 @@ class SDK extends Events {
     _handleNotification(msg) {
         if (msg && msg.type) {
             if (Transformer[msg.type]) {
-                msg = Transformer[msg.type](msg, this);
+                try {
+                    msg = Transformer[msg.type](msg, this);
+                }catch(error) {
+                    throw new ParseError(error, msg);
+                }
             }
             this.emit(msg.type, msg.body);
         }
@@ -314,7 +319,11 @@ class SDK extends Events {
     _handleResponse(msg) {
         if (msg && msg.type) {
             if (Transformer[msg.type]) {
-                msg = Transformer[msg.type](msg, this);
+                try {
+                    msg = Transformer[msg.type](msg, this);
+                }catch(error) {
+                    throw new ParseError(error, msg);
+                }
             }
             this.emit(msg.type, msg.body, msg.reqId);
         }

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -304,13 +304,7 @@ class SDK extends Events {
 
     _handleNotification(msg) {
         if (msg && msg.type) {
-            if (Transformer[msg.type]) {
-                try {
-                    msg = Transformer[msg.type](msg, this);
-                }catch(error) {
-                    throw new TransformError(error, msg);
-                }
-            }
+            msg = this._transformMsg(msg);
             this.emit(msg.type, msg.body);
         }
         this.emit(CONST.EVENTS.NOTIFICATION, msg);
@@ -318,13 +312,7 @@ class SDK extends Events {
 
     _handleResponse(msg) {
         if (msg && msg.type) {
-            if (Transformer[msg.type]) {
-                try {
-                    msg = Transformer[msg.type](msg, this);
-                }catch(error) {
-                    throw new TransformError(error, msg);
-                }
-            }
+            msg = this._transformMsg(msg);
             this.emit(msg.type, msg.body, msg.reqId);
         }
         this._handleOutcome(msg);
@@ -356,6 +344,17 @@ class SDK extends Events {
         }
         this.pendingRequests[id] = null;
         delete this.pendingRequests[id];
+    }
+
+    _transformMsg(msg) {
+        if (Transformer[msg.type]) {
+            try {
+                return Transformer[msg.type](msg, this);
+            } catch (error) {
+                throw new TransformError(error, msg);
+            }
+        }
+        return msg;
     }
 }
 

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -9,7 +9,7 @@ const async = require('async');
 const external = require('./ExternalServices');
 const Transformer = require('./Transformer');
 const SDKError = require('./error/SDKError');
-const ParseError = require('./error/ParseError');
+const TransformError = require('./error/TransformError');
 const CSDSClient = require('./CSDSClient');
 
 /**
@@ -308,7 +308,7 @@ class SDK extends Events {
                 try {
                     msg = Transformer[msg.type](msg, this);
                 }catch(error) {
-                    throw new ParseError(error, msg);
+                    throw new TransformError(error, msg);
                 }
             }
             this.emit(msg.type, msg.body);
@@ -322,7 +322,7 @@ class SDK extends Events {
                 try {
                     msg = Transformer[msg.type](msg, this);
                 }catch(error) {
-                    throw new ParseError(error, msg);
+                    throw new TransformError(error, msg);
                 }
             }
             this.emit(msg.type, msg.body, msg.reqId);

--- a/lib/error/ParseError.js
+++ b/lib/error/ParseError.js
@@ -1,0 +1,11 @@
+'use strict';
+
+class ParseError extends Error {
+    constructor(error, payload) {
+        super(error);
+        this.stack = error.stack;
+        this.payload = payload;
+    }
+}
+
+module.exports = ParseError;

--- a/lib/error/TransformError.js
+++ b/lib/error/TransformError.js
@@ -1,6 +1,6 @@
 'use strict';
 
-class ParseError extends Error {
+class TransformError extends Error {
     constructor(error, payload) {
         super(error);
         this.stack = error.stack;
@@ -8,4 +8,4 @@ class ParseError extends Error {
     }
 }
 
-module.exports = ParseError;
+module.exports = TransformError;

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -332,7 +332,7 @@ describe('Agent SDK Tests', () => {
 
     });
 
-    it('Should throw ParseError when a notification with missing participantsPId is received', done => {
+    it('Should throw a ParseError when a notification with missed participantsPId data is received', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
         externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
@@ -357,7 +357,7 @@ describe('Agent SDK Tests', () => {
 
     });
 
-    it('Should throw ParseError when a response with missing participantsPId is received', done => {
+    it('Should throw a ParseError when a response with missed participantsPId data is received', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
         externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -332,7 +332,7 @@ describe('Agent SDK Tests', () => {
 
     });
 
-    it('Should throw a ParseError when a notification with missed participantsPId data is received', done => {
+    it('Should throw a TransformError when a notification with missed participantsPId data is received', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
         externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
@@ -349,7 +349,7 @@ describe('Agent SDK Tests', () => {
                 expect(err).to.be.defined;
                 expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
                 expect(err.payload.body.changes[0]).to.be.equal(change);
-                expect(err.constructor.name).to.be.equal('ParseError');
+                expect(err.constructor.name).to.be.equal('TransformError');
                 done();
             }
 
@@ -357,7 +357,7 @@ describe('Agent SDK Tests', () => {
 
     });
 
-    it('Should throw a ParseError when a response with missed participantsPId data is received', done => {
+    it('Should throw a TransformError when a response with missed participantsPId data is received', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
         externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
@@ -374,7 +374,7 @@ describe('Agent SDK Tests', () => {
                 expect(err).to.be.defined;
                 expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
                 expect(err.payload.body.changes[0]).to.be.equal(change);
-                expect(err.constructor.name).to.be.equal('ParseError');
+                expect(err.constructor.name).to.be.equal('TransformError');
                 done();
             }
 

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -218,7 +218,7 @@ describe('Agent SDK Tests', () => {
         });
 
         agent.on('myType', body => {
-            expect(body.x).to.equal('x');
+            expect(body).to.be.defined;
             expect(body.x).to.equal('x');
             done();
         });
@@ -332,7 +332,7 @@ describe('Agent SDK Tests', () => {
 
     });
 
-    it('Should thrown ParseError when a notification with missing participantsPId is received', done => {
+    it('Should throw ParseError when a notification with missing participantsPId is received', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
         externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
@@ -357,7 +357,7 @@ describe('Agent SDK Tests', () => {
 
     });
 
-    it('Should thrown ParseError when a response with missing participantsPId is received', done => {
+    it('Should throw ParseError when a response with missing participantsPId is received', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
         externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
@@ -371,6 +371,7 @@ describe('Agent SDK Tests', () => {
             try{
                 agent.transport.emit('message', {kind: 'resp', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
             } catch (err) {
+                console.log(err);
                 expect(err).to.be.defined;
                 expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
                 expect(err.payload.body.changes[0]).to.be.equal(change);

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -218,7 +218,7 @@ describe('Agent SDK Tests', () => {
         });
 
         agent.on('myType', body => {
-            expect(body).to.be.defined;
+            expect(body.x).to.equal('x');
             expect(body.x).to.equal('x');
             done();
         });
@@ -328,6 +328,56 @@ describe('Agent SDK Tests', () => {
             agent.dispose();
             expect(agent.transport).to.be.null;
             done();
+        });
+
+    });
+
+    it('Should thrown ParseError when a notification with missing participantsPId is received', done => {
+        requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
+        externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
+        externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
+        const change =  {'type':'UPSERT','result':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','effectiveTTR':-1,'conversationDetails':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','skillId':'1251428632','participants':{'CONSUMER':['102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11'],'MANAGER':['2344566.1282051932','2344566.901083232'],'CONTROLLER':['2344566.1257599432'],'READER':[]},'participantsPId':{'CONSUMER':['102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11'],'MANAGER':['f675416a-7d5a-5d06-a7bd-bdf5fcc426a1','8ffebb81-0614-568c-a011-3b17eafc5b9d'],'READER':[]},'dialogs':[{'dialogId':'5Yn6I7hpR6C3JWg4YT-Meg','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'}],'dialogType':'POST_SURVEY','channelType':'MESSAGING','metaData':{'appInstallId':'896ef5ea-b954-42c9-91b7-a9134a47faa7'},'state':'OPEN','creationTs':1564734095888,'metaDataLastUpdateTs':1564734095887},{'dialogId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'},{'id':'2344566.1282051932','role':'MANAGER','state':'ACTIVE'},{'id':'2344566.1257599432','role':'CONTROLLER','state':'ACTIVE'},{'id':'2344566.901083232','role':'MANAGER','state':'ACTIVE'}],'dialogType':'MAIN','channelType':'MESSAGING','state':'CLOSE','creationTs':1564685380489,'endTs':1564734095888,'metaDataLastUpdateTs':1564734095888,'closedBy':'AGENT'}],'brandId':'2344566','state':'CLOSE','stage':'OPEN','closeReason':'AGENT','startTs':1564685380489,'metaDataLastUpdateTs':1564734095888,'firstConversation':false,'csatRate':0,'ttr':{'ttrType':'NORMAL','value':1200},'note':'','context':{'type':'CustomContext','clientProperties':{'type':'.ClientProperties','appId':'whatsapp','ipAddress':'10.42.138.108','features':['PHOTO_SHARING','QUICK_REPLIES','AUTO_MESSAGES','MULTI_DIALOG','FILE_SHARING','RICH_CONTENT']},'name':'WhatsApp Business'},'conversationHandlerDetails':{'accountId':'2344566','skillId':'1251428632'}},'numberOfunreadMessages':{'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11':1,'2344566.901083232':0,'2344566.1282051932':10},'lastUpdateTime':1564734095888}};
+        const agent = new Agent({
+            accountId: 'account',
+            username: 'me',
+            password: 'password'
+        });
+        agent.on('connected', msg => {
+            try{
+                agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
+            } catch (err) {
+                expect(err).to.be.defined;
+                expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
+                expect(err.payload.body.changes[0]).to.be.equal(change);
+                expect(err.constructor.name).to.be.equal('ParseError');
+                done();
+            }
+
+        });
+
+    });
+
+    it('Should thrown ParseError when a response with missing participantsPId is received', done => {
+        requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
+        externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
+        externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
+        const change =  {'type':'UPSERT','result':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','effectiveTTR':-1,'conversationDetails':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','skillId':'1251428632','participants':{'CONSUMER':['102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11'],'MANAGER':['2344566.1282051932','2344566.901083232'],'CONTROLLER':['2344566.1257599432'],'READER':[]},'participantsPId':{'CONSUMER':['102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11'],'MANAGER':['f675416a-7d5a-5d06-a7bd-bdf5fcc426a1','8ffebb81-0614-568c-a011-3b17eafc5b9d'],'READER':[]},'dialogs':[{'dialogId':'5Yn6I7hpR6C3JWg4YT-Meg','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'}],'dialogType':'POST_SURVEY','channelType':'MESSAGING','metaData':{'appInstallId':'896ef5ea-b954-42c9-91b7-a9134a47faa7'},'state':'OPEN','creationTs':1564734095888,'metaDataLastUpdateTs':1564734095887},{'dialogId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'},{'id':'2344566.1282051932','role':'MANAGER','state':'ACTIVE'},{'id':'2344566.1257599432','role':'CONTROLLER','state':'ACTIVE'},{'id':'2344566.901083232','role':'MANAGER','state':'ACTIVE'}],'dialogType':'MAIN','channelType':'MESSAGING','state':'CLOSE','creationTs':1564685380489,'endTs':1564734095888,'metaDataLastUpdateTs':1564734095888,'closedBy':'AGENT'}],'brandId':'2344566','state':'CLOSE','stage':'OPEN','closeReason':'AGENT','startTs':1564685380489,'metaDataLastUpdateTs':1564734095888,'firstConversation':false,'csatRate':0,'ttr':{'ttrType':'NORMAL','value':1200},'note':'','context':{'type':'CustomContext','clientProperties':{'type':'.ClientProperties','appId':'whatsapp','ipAddress':'10.42.138.108','features':['PHOTO_SHARING','QUICK_REPLIES','AUTO_MESSAGES','MULTI_DIALOG','FILE_SHARING','RICH_CONTENT']},'name':'WhatsApp Business'},'conversationHandlerDetails':{'accountId':'2344566','skillId':'1251428632'}},'numberOfunreadMessages':{'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11':1,'2344566.901083232':0,'2344566.1282051932':10},'lastUpdateTime':1564734095888}};
+        const agent = new Agent({
+            accountId: 'account',
+            username: 'me',
+            password: 'password'
+        });
+        agent.on('connected', msg => {
+            try{
+                agent.transport.emit('message', {kind: 'resp', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
+            } catch (err) {
+                expect(err).to.be.defined;
+                expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
+                expect(err.payload.body.changes[0]).to.be.equal(change);
+                expect(err.constructor.name).to.be.equal('ParseError');
+                done();
+            }
+
         });
 
     });

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -371,7 +371,6 @@ describe('Agent SDK Tests', () => {
             try{
                 agent.transport.emit('message', {kind: 'resp', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
             } catch (err) {
-                console.log(err);
                 expect(err).to.be.defined;
                 expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
                 expect(err.payload.body.changes[0]).to.be.equal(change);


### PR DESCRIPTION
This will throw an error that contains the UMS notification payload that caused the exception. This is necessary for error handling and investigation when the UMS events don't contain the expected data or some information is missed.