### PR TITLE
Co 1186 handle participants transform issues

### DIFF
--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -390,6 +390,7 @@ class SDK extends Events {
     _handleNotification(msg) {
         if (msg && msg.type) {
             msg = this._transformMsg(msg);
+            if (msg === null) return;
             this.emit(msg.type, msg.body);
         }
         this.emit(CONST.EVENTS.NOTIFICATION, msg);
@@ -398,6 +399,7 @@ class SDK extends Events {
     _handleResponse(msg) {
         if (msg && msg.type) {
             msg = this._transformMsg(msg);
+            if (msg === null) return;
             this.emit(msg.type, msg.body, msg.reqId);
         }
         this._handleOutcome(msg);
@@ -438,6 +440,7 @@ class SDK extends Events {
             } catch (error) {
                 //throw new TransformError(error, msg);
                 this.emit('error', new TransformError(error, msg));
+                return null;
             }
         }
         return msg;

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -436,7 +436,8 @@ class SDK extends Events {
             try {
                 return Transformer[msg.type](msg, this);
             } catch (error) {
-                throw new TransformError(error, msg);
+                //throw new TransformError(error, msg);
+                this.emit('error', new TransformError(error, msg));
             }
         }
         return msg;

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -4,7 +4,7 @@
 function createParticipantsList(conversationDetails, change, agent) {
 
     if (!conversationDetails.hasOwnProperty('participantsPId')) {
-        return [];
+        throw new Error(`participantsPId key property is missing on notification for convId ${change.result.convId}`);
     }
 
     // 1. identify in/out
@@ -37,7 +37,7 @@ function createParticipantsList(conversationDetails, change, agent) {
                 if (dialogParticipant.state === 'SUGGESTED') {
                     return;
                 }
-                let message = `Invalid participant on conversation ${change.result.convId} - ${JSON.stringify(dialogParticipant)}`;
+                let message = `invalid participant on conversation ${change.result.convId} - ${JSON.stringify(dialogParticipant)}`;
                 console.warn(message);
                 agent.emit('warn', {message});
 

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -1,11 +1,13 @@
 'use strict';
 
-function createParticipantsList(conversationDetails, change) {
+// converts participantsPId (v2) to participants (v3)
+function createParticipantsList(conversationDetails, change, agent) {
 
     if (!conversationDetails.hasOwnProperty('participantsPId')) {
         return [];
     }
 
+    // 1. identify in/out
     let participants = [];
     let participantsPId = conversationDetails.participantsPId;
 
@@ -35,7 +37,10 @@ function createParticipantsList(conversationDetails, change) {
                 if (dialogParticipant.state === 'SUGGESTED') {
                     return;
                 }
-                console.warn(`Invalid participant on conversation ${change.result.convId} - ${JSON.stringify(dialogParticipant)}`);
+                let message = `Invalid participant on conversation ${change.result.convId} - ${JSON.stringify(dialogParticipant)}`;
+                console.warn(message);
+                agent.emit('warn', {message});
+
                 return; // ignore for now
             }
 
@@ -76,7 +81,7 @@ module.exports = {
                 conversationDetails.getMyRole = () => conversationDetails.__myRole; // getMyRole is deprecated. Please use sdk.agentId
 
                 // convert participantsPId (v2) to participants (v3), removing participantsPId after
-                conversationDetails.participants = createParticipantsList(conversationDetails, change);
+                conversationDetails.participants = createParticipantsList(conversationDetails, change, agent);
                 delete conversationDetails.participantsPId;
             }
         });

--- a/lib/Transformer.js
+++ b/lib/Transformer.js
@@ -1,5 +1,58 @@
 'use strict';
 
+function createParticipantsList(conversationDetails, change) {
+
+    if (!conversationDetails.hasOwnProperty('participantsPId')) {
+        return [];
+    }
+
+    let participants = [];
+    let participantsPId = conversationDetails.participantsPId;
+
+    // 2. create the initial global roles in participants, based on PIds
+    Object.keys(participantsPId).forEach(role => {
+        // each PId in this role will get an entry in participants
+        participantsPId[role].forEach(id => participants.push({id: id, role: role}))
+    });
+
+    // 3. look at each participant in each dialog, try to overwrite its id from the global list
+    conversationDetails.dialogs.forEach(dialog => {
+        let roleCount = {};
+        dialog.participantsDetails.forEach(dialogParticipant => {
+
+            let role = dialogParticipant.role;
+
+            // ensure we've got a count for this dialogParticipant's role
+            // then get the current count for an index
+            // then increment the count
+            if (!roleCount.hasOwnProperty(role)) roleCount[role] = 0;
+            let pidIndex = roleCount[role];
+            roleCount[role]++;
+
+            // if the global PId list doesn't have this role
+            if (!participantsPId.hasOwnProperty(role)) {
+                // Suggested agents don't show up in the global participants list for some reason
+                if (dialogParticipant.state === 'SUGGESTED') {
+                    return;
+                }
+                console.warn(`Invalid participant on conversation ${change.result.convId} - ${JSON.stringify(dialogParticipant)}`);
+                return; // ignore for now
+            }
+
+            // get the global PIds for this role
+            let rolePIds = participantsPId[role];
+
+            // in case in the dialog there more participants than in the conversation
+            if (pidIndex < rolePIds.length) {
+                dialogParticipant.id = rolePIds[pidIndex];
+            }
+
+        });
+    });
+
+    return participants;
+}
+
 module.exports = {
     '.ams.aam.ExConversationChangeNotification': (msg, agent) => {
         msg.type = 'cqm.ExConversationChangeNotification';
@@ -7,40 +60,23 @@ module.exports = {
             if (change && change.result) {
                 delete change.result.lastUpdateTime;
                 delete change.result.numberOfunreadMessages;
+
                 let conversationDetails = change.result.conversationDetails;
                 delete conversationDetails.convId;
                 delete conversationDetails.note;
                 delete conversationDetails.brandId;
-                // delete cd.firstConversation;
                 delete conversationDetails.groupId;
                 delete conversationDetails.csatRate;
 
-                Object.keys(conversationDetails.participants).forEach(role =>
-                    conversationDetails.participants[role].filter(id => id === agent.__oldAgentId).forEach(() =>
-                        conversationDetails.__myRole = role));
-
-                // getMyRole is deprecated. Please use sdk.agentId
-                conversationDetails.getMyRole = () => conversationDetails.__myRole;
-                conversationDetails.participants = [];
-                Object.keys(conversationDetails.participantsPId).forEach(role =>
-                    conversationDetails.participantsPId[role].forEach(id =>
-                        conversationDetails.participants.push({id: id, role: role})));
-
-                // convert the participants id to the uuid format
-                conversationDetails.dialogs.forEach(dialog => {
-                    let roles = {};
-                    dialog.participantsDetails.forEach(p => {
-                        if (!(p.role in roles)) {
-                            roles[p.role] = 0;
-                        }
-
-                        // in case in the dialog there more paricipants than in the conversation
-                        let participantsPId = conversationDetails.participantsPId[p.role][roles[p.role]];
-                        p.id = participantsPId ? participantsPId : p.id;
-                        roles[p.role]++;
-                    });
+                // find __myRole, if Agent.__oldAgentId === the id
+                Object.keys(conversationDetails.participants).forEach(role => {
+                    let isMyRole = conversationDetails.participants[role].filter(id => id === agent.__oldAgentId).length > 0;
+                    if (isMyRole) conversationDetails.__myRole = role;
                 });
+                conversationDetails.getMyRole = () => conversationDetails.__myRole; // getMyRole is deprecated. Please use sdk.agentId
 
+                // convert participantsPId (v2) to participants (v3), removing participantsPId after
+                conversationDetails.participants = createParticipantsList(conversationDetails, change);
                 delete conversationDetails.participantsPId;
             }
         });

--- a/test/TransformError1.json
+++ b/test/TransformError1.json
@@ -1,0 +1,196 @@
+{
+    "type": "UPSERT",
+    "result": {
+        "convId": "816566d3-3825-4375-b2c6-82bcd000b623",
+        "effectiveTTR": -1,
+        "conversationDetails": {
+            "skillId": "792479851",
+            "participants": {
+                "CONSUMER": [
+                    "1bb11075bd2611b5c4d4d73bfbb156c8afae6de6756fea9f6231cf38b5e5fc84"
+                ],
+                "READER": [
+                    "956e3f43-45e4-5a3d-bfc0-9b7049e81fd3",
+                    "d5edc6a8-f7e9-5eaf-993f-d5a50daa0ac9"
+                ],
+                "MANAGER": [
+                    "956e3f43-45e4-5a3d-bfc0-9b7049e81fd3"
+                ],
+                "CONTROLLER": [
+                    "3175f264-2a40-5b11-99aa-06b0a4020de3"
+                ]
+            },
+            "participantsPId": {
+                "CONSUMER": [
+                    "1bb11075bd2611b5c4d4d73bfbb156c8afae6de6756fea9f6231cf38b5e5fc84"
+                ],
+                "READER": [
+                    "956e3f43-45e4-5a3d-bfc0-9b7049e81fd3",
+                    "d5edc6a8-f7e9-5eaf-993f-d5a50daa0ac9"
+                ],
+                "MANAGER": [
+                    "956e3f43-45e4-5a3d-bfc0-9b7049e81fd3"
+                ],
+                "CONTROLLER": [
+                    "3175f264-2a40-5b11-99aa-06b0a4020de3"
+                ]
+            },
+            "dialogs": [
+                {
+                    "dialogId": "5rLPNzXpRl-oV56TlNuC5g",
+                    "participantsDetails": [
+                        {
+                            "id": "1bb11075bd2611b5c4d4d73bfbb156c8afae6de6756fea9f6231cf38b5e5fc84",
+                            "role": "CONSUMER",
+                            "state": "ACTIVE"
+                        },
+                        {
+                            "id": "956e3f43-45e4-5a3d-bfc0-9b7049e81fd3",
+                            "role": "READER",
+                            "state": "ACTIVE"
+                        },
+                        {
+                            "id": "d5edc6a8-f7e9-5eaf-993f-d5a50daa0ac9",
+                            "role": "READER",
+                            "state": "ACTIVE"
+                        }
+                    ],
+                    "dialogType": "POST_SURVEY",
+                    "channelType": "MESSAGING",
+                    "metaData": {
+                        "appInstallId": "31f55e51-35fc-4187-9742-8c5fcc218048"
+                    },
+                    "state": "OPEN",
+                    "creationTs": 1568004100407,
+                    "metaDataLastUpdateTs": 1568004100406
+                },
+                {
+                    "dialogId": "816566d3-3825-4375-b2c6-82bcd000b623",
+                    "participantsDetails": [
+                        {
+                            "id": "1bb11075bd2611b5c4d4d73bfbb156c8afae6de6756fea9f6231cf38b5e5fc84",
+                            "role": "CONSUMER",
+                            "state": "ACTIVE"
+                        },
+                        {
+                            "id": "3175f264-2a40-5b11-99aa-06b0a4020de3",
+                            "role": "CONTROLLER",
+                            "state": "ACTIVE"
+                        },
+                        {
+                            "id": "956e3f43-45e4-5a3d-bfc0-9b7049e81fd3",
+                            "role": "MANAGER",
+                            "state": "ACTIVE"
+                        },
+                        {
+                            "id": "7149717.880365851",
+                            "role": "ASSIGNED_AGENT",
+                            "state": "SUGGESTED"
+                        }
+                    ],
+                    "dialogType": "MAIN",
+                    "channelType": "MESSAGING",
+                    "state": "CLOSE",
+                    "creationTs": 1568004067509,
+                    "endTs": 1568004100407,
+                    "metaDataLastUpdateTs": 1568004100407,
+                    "closedBy": "CONSUMER",
+                    "closedCause": "Closed by consumer"
+                }
+            ],
+            "state": "CLOSE",
+            "stage": "OPEN",
+            "closeReason": "CONSUMER",
+            "startTs": 1568004067509,
+            "metaDataLastUpdateTs": 1568009422485,
+            "firstConversation": true,
+            "ttr": {
+                "ttrType": "",
+                "ype": ".ClientProperties",
+                "appId": "webAsync",
+                "ipAddress": "10.160.89.81",
+                "deviceFamily": "TABLET",
+                "os": "IOS",
+                "osVersion": "12.3.1",
+                "integration": "WEB_SDK",
+                "integrationVersion": "3.0.25",
+                "browser": "MOBILE_SAFARI",
+                "browserVersion": "12.1.1",
+                "features": [
+                    "PHOTO_SHARING",
+                    "CO_BROWSE",
+                    "QUICK_REPLIES",
+                    "AUTO_MESSAGES",
+                    "MULTI_DIALOG",
+                    "FILE_SHARING",
+                    "RICH_CONTENT"
+                ]
+            },
+            "visitorId": "U3YzBkYzg2OWM4MjUwN2M5",
+            "sessionId": "TLFI1wgCQ8Gxt9cVqj1guA",
+            "interactionContextId": "13"
+        },
+        "conversationHandlerDetails": {
+            "accountId": "7149717",
+            "skillId": "792479851"
+        }
+    },
+    "lastContentEventNotification": {
+        "sequence": 1,
+        "originatorClientProperties": {
+            "type": ".ClientProperties",
+            "appId": "webAsync",
+            "ipAddress": "10.160.89.81",
+            "deviceFamily": "TABLET",
+            "os": "IOS",
+            "osVersion": "12.3.1",
+            "integration": "WEB_SDK",
+            "integrationVersion": "3.0.25",
+            "browser": "MOBILE_SAFARI",
+            "browserVersion": "12.1.1",
+            "features": [
+                "PHOTO_SHARING",
+                "CO_BROWSE",
+                "QUICK_REPLIES",
+                "AUTO_MESSAGES",
+                "MULTI_DIALOG",
+                "FILE_SHARING",
+                "RICH_CONTENT"
+            ]
+        },
+        "originatorId": "1bb11075bd2611b5c4d4d73bfbb156c8afae6de6756fea9f6231cf38b5e5fc84",
+        "originatorPId": "1bb11075bd2611b5c4d4d73bfbb156c8afae6de6756fea9f6231cf38b5e5fc84",
+        "originatorMetadata": {
+            "id": "1bb11075bd2611b5c4d4d73bfbb156c8afae6de6756fea9f6231cf38b5e5fc84",
+            "role": "CONSUMER",
+            "clientProperties": {
+                "type": ".ClientProperties",
+                "appId": "webAsync",
+                "ipAddress": "10.160.89.81",
+                "deviceFamily": "TABLET",
+                "os": "IOS",
+                "osVersion": "12.3.1",
+                "integration": "WEB_SDK",
+                "integrationVersion": "3.0.25",
+                "browser": "MOBILE_SAFARI",
+                "browserVersion": "12.1.1",
+                "features": [
+                    "PHOTO_SHARING",
+                    "CO_BROWSE",
+                    "QUICK_REPLIES",
+                    "AUTO_MESSAGES",
+                    "MULTI_DIALOG",
+                    "FILE_SHARING",
+                    "RICH_CONTENT"
+                ]
+            }
+        },
+        "serverTimestamp": 1568004067782,
+        "event": {
+            "type": "ContentEvent",
+            "message": "こちらをクリック",
+            "contentType": "text/plain"
+        },
+        "dialogId": "816566d3-3825-4375-b2c6-82bcd000b623"
+    }
+}

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -363,42 +363,24 @@ describe('Agent SDK Tests', () => {
             username: 'me',
             password: 'password'
         });
-        agent.on('connected', msg => {
-            try{
-                agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
-            } catch (err) {
-                expect(err).to.be.defined;
-                expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
-                expect(err.payload.body.changes[0]).to.be.equal(change);
-                expect(err.constructor.name).to.be.equal('TransformError');
-                done();
-            }
 
+        let warned = false;
+
+        agent.on('connected', msg => {
+            agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
         });
 
-    });
-
-    it('Should throw a TransformError when a response with missed participantsPId data is received', done => {
-        requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
-        externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
-        externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
-        const change =  {'type':'UPSERT','result':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','effectiveTTR':-1,'conversationDetails':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','skillId':'1251428632','participants':{'CONSUMER':['102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11'],'MANAGER':['2344566.1282051932','2344566.901083232'],'CONTROLLER':['2344566.1257599432'],'READER':[]},'participantsPId':{'CONSUMER':['102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11'],'MANAGER':['f675416a-7d5a-5d06-a7bd-bdf5fcc426a1','8ffebb81-0614-568c-a011-3b17eafc5b9d'],'READER':[]},'dialogs':[{'dialogId':'5Yn6I7hpR6C3JWg4YT-Meg','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'}],'dialogType':'POST_SURVEY','channelType':'MESSAGING','metaData':{'appInstallId':'896ef5ea-b954-42c9-91b7-a9134a47faa7'},'state':'OPEN','creationTs':1564734095888,'metaDataLastUpdateTs':1564734095887},{'dialogId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'},{'id':'2344566.1282051932','role':'MANAGER','state':'ACTIVE'},{'id':'2344566.1257599432','role':'CONTROLLER','state':'ACTIVE'},{'id':'2344566.901083232','role':'MANAGER','state':'ACTIVE'}],'dialogType':'MAIN','channelType':'MESSAGING','state':'CLOSE','creationTs':1564685380489,'endTs':1564734095888,'metaDataLastUpdateTs':1564734095888,'closedBy':'AGENT'}],'brandId':'2344566','state':'CLOSE','stage':'OPEN','closeReason':'AGENT','startTs':1564685380489,'metaDataLastUpdateTs':1564734095888,'firstConversation':false,'csatRate':0,'ttr':{'ttrType':'NORMAL','value':1200},'note':'','context':{'type':'CustomContext','clientProperties':{'type':'.ClientProperties','appId':'whatsapp','ipAddress':'10.42.138.108','features':['PHOTO_SHARING','QUICK_REPLIES','AUTO_MESSAGES','MULTI_DIALOG','FILE_SHARING','RICH_CONTENT']},'name':'WhatsApp Business'},'conversationHandlerDetails':{'accountId':'2344566','skillId':'1251428632'}},'numberOfunreadMessages':{'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11':1,'2344566.901083232':0,'2344566.1282051932':10},'lastUpdateTime':1564734095888}};
-        const agent = new Agent({
-            accountId: 'account',
-            username: 'me',
-            password: 'password'
+        agent.on('warn', msg => {
+            expect(msg).to.be.defined;
+            expect(msg.message).to.contain('Invalid participant on conversation');
+            warned = true;
         });
-        agent.on('connected', msg => {
-            try{
-                agent.transport.emit('message', {kind: 'resp', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
-            } catch (err) {
-                expect(err).to.be.defined;
-                expect(err.message).to.be.equal('TypeError: Cannot read property \'0\' of undefined');
-                expect(err.payload.body.changes[0]).to.be.equal(change);
-                expect(err.constructor.name).to.be.equal('TransformError');
-                done();
-            }
 
+        agent.on('notification', msg => {
+            expect(msg).to.be.defined;
+            expect(msg.body.changes[0].result.conversationDetails.participants.length).to.equal(3);
+            expect(warned).to.equal(true);
+            done();
         });
 
     });
@@ -413,6 +395,7 @@ describe('Agent SDK Tests', () => {
             username: 'me',
             password: 'password'
         });
+        
         agent.on('connected', msg => {
             agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
         });

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -353,7 +353,7 @@ describe('Agent SDK Tests', () => {
 
     });
 
-    it('Should throw a TransformError when a notification with missed participantsPId data is received', done => {
+    it('Should emit a warn (and no error) when a notification with partial participantsPId data is received', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
         externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
@@ -365,6 +365,45 @@ describe('Agent SDK Tests', () => {
         });
 
         let warned = false;
+        let errReceived = false;
+
+        agent.on('connected', msg => {
+            agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
+        });
+
+        agent.on('warn', msg => {
+            expect(msg).to.be.defined;
+            expect(msg.message).to.contain('invalid participant on conversation');
+            warned = true;
+        });
+
+        agent.on('error', err => {
+            errReceived = true;
+        });
+
+        agent.on('notification', msg => {
+            expect(msg).to.be.defined;
+            expect(msg.body.changes[0].result.conversationDetails.participants.length).to.equal(3);
+            expect(warned).to.equal(true);
+            expect(errReceived).to.equal(false);
+            done();
+        });
+
+    });
+
+    it('Should handle suggested participant (no PId entry) without error or warn', done => {
+        requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
+        externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
+        externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
+        const change = JSON.parse(fs.readFileSync(__dirname + '/TransformError1.json').toString());
+        const agent = new Agent({
+            accountId: 'account',
+            username: 'me',
+            password: 'password'
+        });
+
+        let warned = false;
+        let errReceived = false;
 
         agent.on('connected', msg => {
             agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
@@ -376,36 +415,57 @@ describe('Agent SDK Tests', () => {
             warned = true;
         });
 
-        agent.on('notification', msg => {
-            expect(msg).to.be.defined;
-            expect(msg.body.changes[0].result.conversationDetails.participants.length).to.equal(3);
-            expect(warned).to.equal(true);
-            done();
-        });
-
-    });
-
-    it('Should handle suggested participant without error', done => {
-        requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
-        externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
-        externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
-        const change = JSON.parse(fs.readFileSync(__dirname + '/TransformError1.json').toString());
-        const agent = new Agent({
-            accountId: 'account',
-            username: 'me',
-            password: 'password'
-        });
-        
-        agent.on('connected', msg => {
-            agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
+        agent.on('error', err => {
+            errReceived = true;
         });
 
         agent.on('notification', msg => {
             expect(msg).to.be.defined;
             expect(msg.body.changes[0].result.conversationDetails.participants.length).to.equal(5);
+            expect(warned).to.equal(false);
+            expect(errReceived).to.equal(false);
             done();
         });
 
     });
+
+    it('Should emit a TransformError when a notification with no participantsPId is received', done => {
+        requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
+        externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {userId: 'imauser'}});
+        externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
+        const change =  {'type':'UPSERT','result':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','effectiveTTR':-1,'conversationDetails':{'convId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','skillId':'1251428632','participants':{'CONSUMER':['102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11'],'MANAGER':['2344566.1282051932','2344566.901083232'],'CONTROLLER':['2344566.1257599432'],'READER':[]},'dialogs':[{'dialogId':'5Yn6I7hpR6C3JWg4YT-Meg','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'}],'dialogType':'POST_SURVEY','channelType':'MESSAGING','metaData':{'appInstallId':'896ef5ea-b954-42c9-91b7-a9134a47faa7'},'state':'OPEN','creationTs':1564734095888,'metaDataLastUpdateTs':1564734095887},{'dialogId':'38c1ff4b-24e5-2342-8d05-15a62de2daad','participantsDetails':[{'id':'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11','role':'CONSUMER','state':'ACTIVE'},{'id':'2344566.1282051932','role':'MANAGER','state':'ACTIVE'},{'id':'2344566.1257599432','role':'CONTROLLER','state':'ACTIVE'},{'id':'2344566.901083232','role':'MANAGER','state':'ACTIVE'}],'dialogType':'MAIN','channelType':'MESSAGING','state':'CLOSE','creationTs':1564685380489,'endTs':1564734095888,'metaDataLastUpdateTs':1564734095888,'closedBy':'AGENT'}],'brandId':'2344566','state':'CLOSE','stage':'OPEN','closeReason':'AGENT','startTs':1564685380489,'metaDataLastUpdateTs':1564734095888,'firstConversation':false,'csatRate':0,'ttr':{'ttrType':'NORMAL','value':1200},'note':'','context':{'type':'CustomContext','clientProperties':{'type':'.ClientProperties','appId':'whatsapp','ipAddress':'10.42.138.108','features':['PHOTO_SHARING','QUICK_REPLIES','AUTO_MESSAGES','MULTI_DIALOG','FILE_SHARING','RICH_CONTENT']},'name':'WhatsApp Business'},'conversationHandlerDetails':{'accountId':'2344566','skillId':'1251428632'}},'numberOfunreadMessages':{'102f83624a545696f5dd87ecdd6edf394430f3445666ba68b533c847abb11':1,'2344566.901083232':0,'2344566.1282051932':10},'lastUpdateTime':1564734095888}};
+        const agent = new Agent({
+            accountId: 'account',
+            username: 'me',
+            password: 'password'
+        });
+
+        let warned = false;
+        let notificationReceived = false;
+
+        agent.on('connected', msg => {
+            agent.transport.emit('message', {kind: 'notification', type: '.ams.aam.ExConversationChangeNotification', body: { changes:[change]}});
+        });
+
+        agent.on('warn', msg => {
+            warned = true;
+        });
+
+        agent.on('notification', msg => {
+            notificationReceived = true;
+        });
+
+        agent.on('error', err => {
+            setTimeout(() => {
+                expect(err).to.be.defined;
+                expect(warned).to.equal(false);
+                expect(notificationReceived).to.equal(false);
+                done();
+            }, 100);
+        });
+
+    });
+
+
 
 });


### PR DESCRIPTION
First off, throwing an error that can only be caught using "uncaughtException" is a bad practice. Instead the AgentSDK object will emit "error" events when they are caught.

Second, sometimes the participantsPId will not have an entry for a participant in one of the dialogs. In these cases the user will be ignored and omitted from the event that is emitted as "notification", a "warn" will also be emitted with a message "invalid participant on conversation". If this user's state is "SUGGESTED", no warn will be emitted.