### PR TITLE
Update Transport to support keep alive heartbeat

### DIFF
--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -25,7 +25,8 @@ const WS_EVENTS = {
     OPEN: 'open',
     CLOSE: 'close',
     ERROR: 'error',
-    MESSAGE: 'message'
+    MESSAGE: 'message',
+    PONG: 'pong'
 };
 
 class Transport extends Events {
@@ -42,6 +43,7 @@ class Transport extends Events {
             this.configuration
         );
         this._bindWsEvents();
+        this.isAlive = true;
     }
 
     _bindWsEvents() {
@@ -49,6 +51,7 @@ class Transport extends Events {
         this.ws.on(WS_EVENTS.CLOSE, this._onClose.bind(this));
         this.ws.on(WS_EVENTS.ERROR, this._onError.bind(this));
         this.ws.on(WS_EVENTS.MESSAGE, this._onMessage.bind(this));
+        this.ws.on(WS_EVENTS.PONG, this._onPong.bind(this));
     }
 
     _unbindWsEvents() {
@@ -56,21 +59,21 @@ class Transport extends Events {
         this.ws.removeListener(WS_EVENTS.CLOSE, this._onClose);
         this.ws.removeListener(WS_EVENTS.ERROR, this._onError);
         this.ws.removeListener(WS_EVENTS.MESSAGE, this._onMessage);
+        this.ws.removeListener(WS_EVENTS.PONG, this._onPong);
     }
 
     _onOpen() {
         this.emit('open');
-        this.ping();
+        this._keepAlive();
     }
 
     _onClose(code, reason) {
         this.emit('close', code, reason);
-        clearTimeout(this.timoutId);
+        clearInterval(this.heartbeat);
     }
 
     _onError(err) {
         this.emit('error', err);
-        clearTimeout(this.timoutId);
     }
 
     _onMessage(data, flags) {
@@ -83,16 +86,17 @@ class Transport extends Events {
         this.emit('message', parsed || data, flags);
     }
 
-    ping() {
-        try {
+    _onPong(data) {
+        this.emit('pong', data);
+        this.isAlive = true;
+    }
+
+    _keepAlive() {
+        this.heartbeat = setInterval( () => {
+            if (this.isAlive == false) return this.ws.terminate();
+            this.isAlive = false;
             this.ws.ping();
-            this.timoutId = setTimeout(() => {
-                this.ping();
-            }, this.pingInterval);
-        }
-        catch (err) {
-            this.emit('error', err);
-        }
+        }, this.pingInterval );
     }
 
     send(message) {
@@ -106,11 +110,12 @@ class Transport extends Events {
     }
 
     close() {
-        clearTimeout(this.timoutId);
+        clearInterval(this.heartbeat);
         this._unbindWsEvents();
         this.ws.terminate();
         this.ws = null;
     }
+
 }
 
 Transport.WS_EVENTS = WS_EVENTS;


### PR DESCRIPTION
Replaced ping logic in Transport.js with keep alive heartbeat(ping/pong) as suggested from the ws library on broken connections. Added new ws event 'pong' so that Agent class can implement callbacks.

https://github.com/websockets/ws#how-to-detect-and-close-broken-connections