### PR TITLE
Update README fix backoff reconnect code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1307,7 +1307,7 @@ agent.on('closed', () => {
 agent._reconnect = (delay = reconnectInterval, attempt = 1) => {
     agent._retryConnection = setTimeout(()=>{
         agent.reconnect();
-        if (++attempt <= reconnectAttempts) { agent._reconnect(reconnectInterval * reconnectRatio, attempt) }
+        if (++attempt <= reconnectAttempts) { agent._reconnect(delay * reconnectRatio, attempt) }
     }, delay * 1000)
  }
 ```


### PR DESCRIPTION
The readme has a recommended backoff reconnect code. However as listed the code never actually backs-off it stays constant at 6.25s. I have updated the readme code to fix this by replacing reconnectInterval which is constant to delay which is what you want.