### PR TITLE
Refactor AgentSDK: refreshSession and public interfaces

### DIFF
--- a/examples/agent-bot/main.js
+++ b/examples/agent-bot/main.js
@@ -45,8 +45,8 @@ echoAgent.on(echoAgent.CONTENT_NOTIFICATION,(contentEvent)=>{
         echoAgent.publishEvent({
             dialogId: contentEvent.dialogId,
             event: {
-                type: 'ContentEvent', 
-                contentType: 'text/plain', 
+                type: 'ContentEvent',
+                contentType: 'text/plain',
                 message: `echo : ${contentEvent.message}`
             }
         });

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -152,9 +152,10 @@ class SDK extends Events {
 
         // 1. get CSDS entries
         this.csdsClient.getAll((err, domains) => {
-
-            this._emitStatusEvents(err, 'Reconnect#CSDS');
-            if (err || !domains) {
+            const domainsError = !domains ? new SDKError('could not fetch domains on reconnect', null) : null;
+            const actualError = err ? err : domainsError;
+            this._emitStatusEvents(actualError, 'Reconnect#CSDS');
+            if (actualError) {
                 return;
             }
 

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -231,6 +231,7 @@ class SDK extends Events {
                 }
             }
         ], (err) => {
+            this._emitStatusEvents(err, 'RefreshSession#CompleteFlow')
             sessionCallback(err);
         });
     }

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -332,9 +332,9 @@ class SDK extends Events {
 
                 // Re-login on 401
                 if (err && err.code === 401) {
-                    this._handleRefreshSessionRelogin(domains, (err) => callback(null, err));
+                    this._handleRefreshSessionRelogin(domains, (err) => callback(err));
                 } else {
-                    callback(null, err);
+                    callback(err);
                 }
             }
         ], (err) => {

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -196,7 +196,7 @@ class SDK extends Events {
                 this.jar = cookies;
                 this.csrf = data.csrf;
                 this.token = data.bearer;
-                this._refreshSession();
+                this._startRefreshSession();
             }
 
             callback(err, data && data.bearer, domains);
@@ -295,19 +295,74 @@ class SDK extends Events {
         this.connected = false;
     }
 
-    _refreshSession(err, data) {
-        clearTimeout(this.refreshSessionTimeoutId);
-        this.csdsClient.getAll((csdsErr, domains) => {
-            if (!err && !csdsErr && (!data || !data.error) && this.csrf && domains) {
-                this.refreshSessionTimeoutId = setTimeout(() => external.refreshSession({
-                    accountId: this.accountId,
-                    domain: domains.agentVep,
-                    csrf: this.csrf,
-                    jar: this.jar
-                }, (err, data) => this._refreshSession(err, data)), this.refreshSessionInterval);
-            } else {
-                this.emit('error', err || new SDKError('could not refresh token', 401));
+    _startRefreshSession() {
+        // Cancel all refresh session
+        if (this.refreshSessionTimeoutId) {
+            clearInterval(this.refreshSessionTimeoutId);
+        }
+
+        // Immediately call _handleRefreshSessionFlow
+        this._handleRefreshSessionFlow();
+
+        // Start periodic call
+        this.refreshSessionTimeoutId = setInterval(() => {
+            this._handleRefreshSessionFlow();
+        }, this.refreshSessionInterval);
+    }
+
+    _handleRefreshSessionFlow() {
+        async.waterfall([
+            // 1. Get CSDS domain
+            (callback) => this.csdsClient.getAll((err, domains) => {
+                callback(null, err, domains)
+            }),
+
+            // 2. Call Refresh Session
+            (err, domains, callback) => {
+                this._emitStatusEvents(err, 'RefreshSession#CSDS');
+
+                if (err) {
+                    return;
+                }
+
+                this._handleRefreshSessionCall(domains, (err, domains, data) => {
+                    callback(null, err, domains, data);
+                });
+            },
+
+            // 3. Call re-login when 401 is encountered
+            (err, domains, _data) => {
+                this._emitStatusEvents(err, 'RefreshSession#REST');
+
+                // Re-login on 401
+                if (err && err.code === 401) {
+                    this._login(this.conf, domains, (err, _token, _domains) => {
+                        this._emitStatusEvents(err, 'RefreshSession#Relogin');
+                    });
+                }
             }
+        ]);
+    }
+
+
+    // Reports if an async task is successful or not
+    _emitStatusEvents(err, location) {
+        const context = { location };
+        if (err) {
+            this.emit('error', err, context);
+        } else {
+            this.emit('success', context);
+        }
+    }
+
+    _handleRefreshSessionCall(domains, callback) {
+        external.refreshSession({
+            accountId: this.accountId,
+            domain: domains.agentVep,
+            csrf: this.csrf,
+            jar: this.jar
+        }, (err, data) => {
+           callback(err, domains, data);
         });
     }
 

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -72,12 +72,26 @@ class SDK extends Events {
 
         // create the CSDS client
         this.csdsClient = new CSDSClient(this.conf);
+        this.accountId = conf.accountId;
 
         // connect
-        this._connect();
+        this.connect((err) => {
+            if (err) {
+                console.error('Error connecting agent..', err);
+            }
+        });
     }
 
-    _connect() {
+    /**************************************************
+     *              Public Interfaces                 *
+     **************************************************/
+
+    /**
+     * Login the agent
+     * @param loginCallback - function(err, token, domains) - Callback function
+     * where the error object, bearer token, and LP service domains are provided
+     */
+    login(loginCallback) {
         async.waterfall([
             // 1. get CSDS entries
             (callback) => this.csdsClient.getAll(callback),
@@ -88,14 +102,27 @@ class SDK extends Events {
 
             // 2. login
             (domains, callback) => this._login(this.conf, domains, callback)
-
         ], (err, token, domains) => {
-            const tokenError = !token ? new SDKError('could not generate token', null) : null;
-            const actualError = err ? err : tokenError;
-            this._emitStatusEvents(actualError, 'Connect#Login');
+            loginCallback(err, token, domains);
+        });
+    }
 
-            if (actualError) {
-                return;
+    /**
+     * Establish a WS connection for the agent. This also logins the agent.
+     * You might want to call this function in the very beginning of the agent lifecycle.
+     * @param connectCallback - function(err) - Callback function where the error object will be provided
+     */
+    connect(connectCallback) {
+        async.waterfall([
+            (callback) => this.login((err, token, domains) => {
+                const tokenError = !token ? new SDKError('could not generate token', null) : null;
+                const actualError = err ? err : tokenError;
+                this._emitStatusEvents(actualError, 'Connect#Login');
+                callback(actualError, token, domains);
+            })
+        ], (err, token, domains) => {
+            if (err) {
+                return connectCallback(err);
             }
 
             // 3. init
@@ -104,11 +131,17 @@ class SDK extends Events {
                 token: token
             }, this.conf));
 
+            connectCallback(null);
         });
     }
 
+    /**
+     * Reconnect WS connections for agents
+     * You might want to call this function in an event of a failure, when the connection will need
+     * to be re-established
+     * @param dontRegenerateToken - if this flag is true, the agent will not try to get a new bearer token, and only reconnect the WS connection
+     */
     reconnect(dontRegenerateToken) {
-
         if (dontRegenerateToken) {
             if (this.transport) this.transport.reconnect();
             return;
@@ -128,9 +161,83 @@ class SDK extends Events {
             this._loginAndReconnect(domains, (err) => {
                 this._emitStatusEvents(err, 'Reconnect#Relogin#WS');
             });
-
         });
     }
+
+    /**
+     * Dispose all connections, event listeners, and timers connected to this agent
+     * You might want to call this function in the end of the agent life cycle
+     */
+    dispose() {
+        clearTimeout(this.errorTimeoutId);
+        clearTimeout(this.refreshSessionTimeoutId);
+        if (this.transport) {
+            this.transport.removeAllListeners('open');
+            this.transport.close();
+        }
+        this.removeAllListeners();
+        this.transport = null;
+        this.connected = false;
+    }
+
+    /**
+     * Start a periodic call to refresh the HTTP session, thus prolonging the lifetime of the bearer token
+     * The default time for the interval of call is 10 minutes.
+     */
+    startPeriodicRefreshSession() {
+        // Cancel all refresh session
+        clearTimeout(this.refreshSessionTimeoutId);
+
+        // Start periodic call
+        this.refreshSessionTimeoutId = setTimeout(() => {
+            this.refreshSession(() => {
+                // Re-call function after the last one passed
+                this.startPeriodicRefreshSession();
+            });
+        }, this.refreshSessionInterval);
+    }
+
+    /**
+     * Asynchronously refresh the HTTP session of the agent, thus prolonging the bearer token lifetime
+     * @param sessionCallback - function(err: Error) - the callback to check for errors
+     */
+    refreshSession(sessionCallback) {
+        async.waterfall([
+            // 1. Get CSDS domain
+            (callback) => this._handleRefreshSessionCSDS((err, domains) => {
+                callback(null, err, domains);
+            }),
+
+            // 2. Call Refresh Session
+            (err, domains, callback) => {
+                // Propagate error from CSDS right away
+                if (err) {
+                    return callback(null, err, domains);
+                }
+
+                this._handleRefreshSessionCall(domains, (err, domains, _data) => {
+                    callback(null, err, domains);
+                });
+            },
+
+            // 3. Call re-login when 401 is encountered
+            (err, domains, callback) => {
+
+                // Re-connect on 401
+                if (err && err.code === 401) {
+                    this._handleRefreshSessionReconnect(domains, (err) => callback(err));
+                } else {
+                    callback(err);
+                }
+            }
+        ], (err) => {
+            sessionCallback(err);
+        });
+    }
+
+    /**************************************************
+     *              Private Interfaces                *
+     **************************************************/
 
     _loginAndReconnect(domains, callback) {
         this._login(this.conf, domains, (err, token) => {
@@ -176,8 +283,6 @@ class SDK extends Events {
                 return callback(err, null, domains);
             }
 
-            this.accountId = conf.accountId;
-
             this.agentId = data && data.config && data.config.userPid;
 
             // get userId and use to generate __oldAgentId
@@ -209,7 +314,7 @@ class SDK extends Events {
                 this.jar = cookies;
                 this.csrf = data.csrf;
                 this.token = data.bearer;
-                this._refreshSession();
+                this.startPeriodicRefreshSession();
             }
 
             callback(err, data && data.bearer, domains);
@@ -296,66 +401,6 @@ class SDK extends Events {
         return this._queueForResponseAndSend(msg, callback);
     }
 
-    dispose() {
-        clearTimeout(this.errorTimeoutId);
-        clearTimeout(this.refreshSessionTimeoutId);
-        if (this.transport) {
-            this.transport.removeAllListeners('open');
-            this.transport.close();
-        }
-        this.removeAllListeners();
-        this.transport = null;
-        this.connected = false;
-    }
-
-    _refreshSession() {
-        // Cancel all refresh session
-        clearTimeout(this.refreshSessionTimeoutId);
-
-        // Start periodic call
-        this.refreshSessionTimeoutId = setTimeout(() => {
-            this._handleRefreshSessionFlow(() => {
-                // Re-call function after the last one passed
-                this._refreshSession();
-            });
-        }, this.refreshSessionInterval);
-    }
-
-    _handleRefreshSessionFlow(sessionCallback) {
-        async.waterfall([
-            // 1. Get CSDS domain
-            (callback) => this._handleRefreshSessionCSDS((err, domains) => {
-                callback(null, err, domains);
-            }),
-
-            // 2. Call Refresh Session
-            (err, domains, callback) => {
-                // Propagate error from CSDS right away
-                if (err) {
-                    return callback(null, err, domains);
-                }
-
-                this._handleRefreshSessionCall(domains, (err, domains, _data) => {
-                    callback(null, err, domains);
-                });
-            },
-
-            // 3. Call re-login when 401 is encountered
-            (err, domains, callback) => {
-
-                // Re-connect on 401
-                if (err && err.code === 401) {
-                    this._handleRefreshSessionReconnect(domains, (err) => callback(err));
-                } else {
-                    callback(err);
-                }
-            }
-        ], (err) => {
-            sessionCallback(err);
-        });
-    }
-
-
     // Reports if an async task is successful or not
     _emitStatusEvents(err, location) {
         const context = { location };
@@ -377,7 +422,7 @@ class SDK extends Events {
     // Handle re-login calls from refreshSession
     _handleRefreshSessionReconnect(domains, callback) {
         this._loginAndReconnect(domains, (err, _token, _domains) => {
-            this._emitStatusEvents(err, 'RefreshSession#Relogin');
+            this._emitStatusEvents(err, 'RefreshSession#Relogin#WS');
             callback(err);
         });
     }

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -28,6 +28,7 @@ const CSDSClient = require('./CSDSClient');
  *     requestTimeout: Number, // default to 10000 milliseconds
  *     errorCheckInterval: Number, // defaults to 1000 milliseconds
  *     apiVersion: Number // Messaging API version - defaults to 2 (version 1 is not supported anymore)
+ *     refreshSessionInterval: Number // Interval of bearer token refresh
  * }
  *
  * @property {Function} subscribeExConversations
@@ -47,6 +48,10 @@ const CSDSClient = require('./CSDSClient');
  * @property {Function} publishEvent
  * @property {Function} reconnect
  * @property {Function} dispose
+ * @property {Function} connect
+ * @property {Function} startPeriodicRefreshSession
+ * @property {Function} refreshSession
+ * @property {Function} getBearerToken
  */
 class SDK extends Events {
 
@@ -75,37 +80,12 @@ class SDK extends Events {
         this.accountId = conf.accountId;
 
         // connect
-        this.connect((err) => {
-            if (err) {
-                console.error('Error connecting agent..', err);
-            }
-        });
+        this.connect(() => {});
     }
 
     /**************************************************
      *              Public Interfaces                 *
      **************************************************/
-
-    /**
-     * Login the agent
-     * @param loginCallback - function(err, token, domains) - Callback function
-     * where the error object, bearer token, and LP service domains are provided
-     */
-    login(loginCallback) {
-        async.waterfall([
-            // 1. get CSDS entries
-            (callback) => this.csdsClient.getAll(callback),
-            (domains, callback) => {
-                Object.assign(domains, this.conf.domains);
-                callback(null, domains);
-            },
-
-            // 2. login
-            (domains, callback) => this._login(this.conf, domains, callback)
-        ], (err, token, domains) => {
-            loginCallback(err, token, domains);
-        });
-    }
 
     /**
      * Establish a WS connection for the agent. This also logins the agent.
@@ -114,12 +94,15 @@ class SDK extends Events {
      */
     connect(connectCallback) {
         async.waterfall([
-            (callback) => this.login((err, token, domains) => {
-                const tokenError = !token ? new SDKError('could not generate token', null) : null;
-                const actualError = err ? err : tokenError;
-                this._emitStatusEvents(actualError, 'Connect#Login');
-                callback(actualError, token, domains);
-            })
+            // 1. get CSDS entries
+            (callback) => this._handleCSDS('Connect#CSDS', callback),
+            (domains, callback) => {
+                Object.assign(domains, this.conf.domains);
+                callback(null, domains);
+            },
+
+            // 2. login
+            (domains, callback) => this._handleLogin(domains, 'Connect#Login', callback),
         ], (err, token, domains) => {
             if (err) {
                 return connectCallback(err);
@@ -159,9 +142,7 @@ class SDK extends Events {
                 return;
             }
 
-            this._loginAndReconnect(domains, (err) => {
-                this._emitStatusEvents(err, 'Reconnect#Relogin#WS');
-            });
+            this._handleLoginAndReconnect(domains, 'Reconnect#Relogin#WS', () => {});
         });
     }
 
@@ -179,6 +160,14 @@ class SDK extends Events {
         this.removeAllListeners();
         this.transport = null;
         this.connected = false;
+    }
+
+    /**
+     * Get the bearer token of the current agent
+     * @returns {String.bearer|*}
+     */
+    getBearerToken() {
+        return this.token;
     }
 
     /**
@@ -203,36 +192,35 @@ class SDK extends Events {
      * @param sessionCallback - function(err: Error) - the callback to check for errors
      */
     refreshSession(sessionCallback) {
+        const error = this._preCheckRefreshSession();
+        if (error) {
+            return sessionCallback(error);
+        }
+
         async.waterfall([
             // 1. Get CSDS domain
-            (callback) => this._handleRefreshSessionCSDS((err, domains) => {
-                callback(null, err, domains);
-            }),
+            (callback) => this._handleCSDS('RefreshSession#CSDS', callback),
 
             // 2. Call Refresh Session
-            (err, domains, callback) => {
-                // Propagate error from CSDS right away
-                if (err) {
-                    return callback(null, err, domains);
-                }
+            (domains, callback) => {
 
-                this._handleRefreshSessionCall(domains, (err, domains, _data) => {
+                // Will still need to go to the next async step to check for error codes
+                this._handleRefreshSessionCall(domains, 'RefreshSession#REST', (err, domains) => {
                     callback(null, err, domains);
                 });
             },
 
-            // 3. Call re-login when 401 is encountered
+            // 3. Call re-login when 401 is encountered (need the error object from previous task to be propagated)
             (err, domains, callback) => {
 
                 // Re-connect on 401
                 if (err && err.code === 401) {
-                    this._handleRefreshSessionReconnect(domains, (err) => callback(err));
+                    this._handleLoginAndReconnect(domains, 'RefreshSession#Relogin#WS', callback);
                 } else {
                     callback(err);
                 }
             }
         ], (err) => {
-            this._emitStatusEvents(err, 'RefreshSession#CompleteFlow')
             sessionCallback(err);
         });
     }
@@ -413,33 +401,50 @@ class SDK extends Events {
         }
     }
 
-    // Handle CSDS calls from refreshSession
-    _handleRefreshSessionCSDS(callback) {
+    // Handle CSDS calls and emit specific events based on error
+    _handleCSDS(location, callback) {
         this.csdsClient.getAll((err, domains) => {
-            this._emitStatusEvents(err, 'RefreshSession#CSDS');
+            this._emitStatusEvents(err, location);
             callback(err, domains);
         });
     }
 
-    // Handle re-login calls from refreshSession
-    _handleRefreshSessionReconnect(domains, callback) {
-        this._loginAndReconnect(domains, (err, _token, _domains) => {
-            this._emitStatusEvents(err, 'RefreshSession#Relogin#WS');
+    // Handle login calls and emit specific events based on error
+    _handleLogin(domains, location, callback) {
+        this._login(this.conf, domains, (err, token, domains) => {
+            const tokenError = !token ? new SDKError('could not generate token', null) : null;
+            const actualError = err ? err : tokenError;
+            this._emitStatusEvents(actualError, location);
+            callback(actualError, token, domains);
+        });
+    }
+
+    // Handle login and reconnect and emit specific events base on error
+    _handleLoginAndReconnect(domains, location, callback) {
+        this._loginAndReconnect(domains, (err) => {
+            this._emitStatusEvents(err, location);
             callback(err);
         });
     }
 
     // Handle Refresh Session calls
-    _handleRefreshSessionCall(domains, callback) {
+    _handleRefreshSessionCall(domains, location, callback) {
         external.refreshSession({
             accountId: this.accountId,
             domain: domains.agentVep,
             csrf: this.csrf,
             jar: this.jar
-        }, (err, _data) => {
-            this._emitStatusEvents(err, 'RefreshSession#REST');
+        }, (err) => {
+            this._emitStatusEvents(err, location);
             callback(err, domains);
         });
+    }
+
+    _preCheckRefreshSession() {
+        const isCSRForJarUndefined = !this.csrf || !this.jar;
+        const error = isCSRForJarUndefined ? new SDKError('CSRF and JAR are not defined for this agent. Please reconnect with bearer token.', null) : null;
+        this._emitStatusEvents(error, 'RefreshSession#Precheck');
+        return error;
     }
 
     _handleMessage(msg) {

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -196,7 +196,7 @@ class SDK extends Events {
                 this.jar = cookies;
                 this.csrf = data.csrf;
                 this.token = data.bearer;
-                this._startRefreshSession();
+                this._refreshSession();
             }
 
             callback(err, data && data.bearer, domains);
@@ -295,53 +295,51 @@ class SDK extends Events {
         this.connected = false;
     }
 
-    _startRefreshSession() {
+    _refreshSession() {
         // Cancel all refresh session
-        if (this.refreshSessionTimeoutId) {
-            clearInterval(this.refreshSessionTimeoutId);
-        }
-
-        // Immediately call _handleRefreshSessionFlow
-        this._handleRefreshSessionFlow();
+        clearTimeout(this.refreshSessionTimeoutId);
 
         // Start periodic call
-        this.refreshSessionTimeoutId = setInterval(() => {
-            this._handleRefreshSessionFlow();
+        this.refreshSessionTimeoutId = setTimeout(() => {
+            this._handleRefreshSessionFlow(() => {
+                // Re-call function after the last one passed
+                this._refreshSession();
+            });
         }, this.refreshSessionInterval);
     }
 
-    _handleRefreshSessionFlow() {
+    _handleRefreshSessionFlow(sessionCallback) {
         async.waterfall([
             // 1. Get CSDS domain
-            (callback) => this.csdsClient.getAll((err, domains) => {
-                callback(null, err, domains)
+            (callback) => this._handleRefreshSessionCSDS((err, domains) => {
+                callback(null, err, domains);
             }),
 
             // 2. Call Refresh Session
             (err, domains, callback) => {
-                this._emitStatusEvents(err, 'RefreshSession#CSDS');
-
+                // Propagate error from CSDS right away
                 if (err) {
-                    return;
+                    return callback(null, err, domains);
                 }
 
-                this._handleRefreshSessionCall(domains, (err, domains, data) => {
-                    callback(null, err, domains, data);
+                this._handleRefreshSessionCall(domains, (err, domains, _data) => {
+                    callback(null, err, domains);
                 });
             },
 
             // 3. Call re-login when 401 is encountered
-            (err, domains, _data) => {
-                this._emitStatusEvents(err, 'RefreshSession#REST');
+            (err, domains, callback) => {
 
                 // Re-login on 401
                 if (err && err.code === 401) {
-                    this._login(this.conf, domains, (err, _token, _domains) => {
-                        this._emitStatusEvents(err, 'RefreshSession#Relogin');
-                    });
+                    this._handleRefreshSessionRelogin(domains, (err) => callback(null, err));
+                } else {
+                    callback(null, err);
                 }
             }
-        ]);
+        ], (err) => {
+            sessionCallback(err);
+        });
     }
 
 
@@ -355,14 +353,32 @@ class SDK extends Events {
         }
     }
 
+    // Handle CSDS calls from refreshSession
+    _handleRefreshSessionCSDS(callback) {
+        this.csdsClient.getAll((err, domains) => {
+            this._emitStatusEvents(err, 'RefreshSession#CSDS');
+            callback(err, domains);
+        });
+    }
+
+    // Handle re-login calls from refreshSession
+    _handleRefreshSessionRelogin(domains, callback) {
+        this._login(this.conf, domains, (err, _token, _domains) => {
+            this._emitStatusEvents(err, 'RefreshSession#Relogin');
+            callback(err);
+        });
+    }
+
+    // Handle Refresh Session calls
     _handleRefreshSessionCall(domains, callback) {
         external.refreshSession({
             accountId: this.accountId,
             domain: domains.agentVep,
             csrf: this.csrf,
             jar: this.jar
-        }, (err, data) => {
-           callback(err, domains, data);
+        }, (err, _data) => {
+            this._emitStatusEvents(err, 'RefreshSession#REST');
+            callback(err, domains);
         });
     }
 

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -90,15 +90,19 @@ class SDK extends Events {
             (domains, callback) => this._login(this.conf, domains, callback)
 
         ], (err, token, domains) => {
-            if (err || !token) {
-                this.emit('error', err || new Error('could not generate token'));
-            } else {
-                // 3. init
-                this._init(Object.assign({
-                    domain: domains.asyncMessagingEnt,
-                    token: token
-                }, this.conf));
+            const actualErr = !token ? new SDKError('could not generate token', null) : err;
+            this._emitStatusEvents(actualErr, 'Connect#Login');
+
+            if (actualErr) {
+                return;
             }
+
+            // 3. init
+            this._init(Object.assign({
+                domain: domains.asyncMessagingEnt,
+                token: token
+            }, this.conf));
+
         });
     }
 
@@ -115,29 +119,37 @@ class SDK extends Events {
         // 1. get CSDS entries
         this.csdsClient.getAll((err, domains) => {
 
+            this._emitStatusEvents(err, 'Reconnect#CSDS');
             if (err || !domains) {
-                this.emit('error', err || new Error('could not fetch domains on reconnect'));
                 return;
             }
 
-            // 2. login
-            this._login(this.conf, domains, (err, token) => {
-                if (err || !token) {
-                    this.emit('error', err || new Error('could not generate token'));
-                } else if (this.transport) {
-                    this.transport.configuration.token = token;
-                    this.transport.reconnect();
-                } else {
-                    // 3. init
-                    this._init(Object.assign({
-                        domain: domains.asyncMessagingEnt,
-                        token: token
-                    }, this.conf));
-                }
+            this._loginAndReconnect(domains, (err) => {
+                this._emitStatusEvents(err, 'Reconnect#Relogin#WS');
             });
 
         });
+    }
 
+    _loginAndReconnect(domains, callback) {
+        this._login(this.conf, domains, (err, token) => {
+            if (err) {
+                callback(err);
+            } else if (!token) {
+                callback(new SDKError('could not generate token', null));
+            } else if (this.transport) {
+                this.transport.configuration.token = token;
+                this.transport.reconnect();
+                callback(null);
+            } else {
+                // 3. init
+                this._init(Object.assign({
+                    domain: domains.asyncMessagingEnt,
+                    token: token
+                }, this.conf));
+                callback(null);
+            }
+        });
     }
 
     // gets a bearer token from agentVEP
@@ -330,9 +342,9 @@ class SDK extends Events {
             // 3. Call re-login when 401 is encountered
             (err, domains, callback) => {
 
-                // Re-login on 401
+                // Re-connect on 401
                 if (err && err.code === 401) {
-                    this._handleRefreshSessionRelogin(domains, (err) => callback(err));
+                    this._handleRefreshSessionReconnect(domains, (err) => callback(err));
                 } else {
                     callback(err);
                 }
@@ -362,8 +374,8 @@ class SDK extends Events {
     }
 
     // Handle re-login calls from refreshSession
-    _handleRefreshSessionRelogin(domains, callback) {
-        this._login(this.conf, domains, (err, _token, _domains) => {
+    _handleRefreshSessionReconnect(domains, callback) {
+        this._loginAndReconnect(domains, (err, _token, _domains) => {
             this._emitStatusEvents(err, 'RefreshSession#Relogin');
             callback(err);
         });

--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -90,10 +90,11 @@ class SDK extends Events {
             (domains, callback) => this._login(this.conf, domains, callback)
 
         ], (err, token, domains) => {
-            const actualErr = !token ? new SDKError('could not generate token', null) : err;
-            this._emitStatusEvents(actualErr, 'Connect#Login');
+            const tokenError = !token ? new SDKError('could not generate token', null) : null;
+            const actualError = err ? err : tokenError;
+            this._emitStatusEvents(actualError, 'Connect#Login');
 
-            if (actualErr) {
+            if (actualError) {
                 return;
             }
 

--- a/lib/ExternalServices.js
+++ b/lib/ExternalServices.js
@@ -57,7 +57,8 @@ function refreshSession(options, callback) {
 
 function compileError(baseErrorMessage, err, response, body) {
     if (body && body.error) {
-        return new SDKError(`${baseErrorMessage}: ${body.error}`, body.internalCode);
+        const code = body.error.includes('UNAUTHORIZED') ? 401 : body.internalCode;
+        return new SDKError(`${baseErrorMessage}: ${body.error}`, code);
     }
 
     // Any status code that is bigger than 2xx

--- a/lib/ExternalServices.js
+++ b/lib/ExternalServices.js
@@ -56,14 +56,13 @@ function refreshSession(options, callback) {
 }
 
 function compileError(baseErrorMessage, err, response, body) {
-    if (body && body.error) {
-        const code = body.error.includes('UNAUTHORIZED') ? 401 : body.internalCode;
-        return new SDKError(`${baseErrorMessage}: ${body.error}`, code);
-    }
-
     // Any status code that is bigger than 2xx
     if (response && response.statusCode > 299) {
-        return new SDKError(`${baseErrorMessage}: ${getAdditionalResponseMessage(response.statusCode)}`, response.statusCode);
+        return new SDKError(`${baseErrorMessage}: ${response.statusMessage}`, response.statusCode);
+    }
+
+    if (body && body.error) {
+        return new SDKError(`${baseErrorMessage}: ${JSON.stringify(body.error)}`, body.error.internalCode);
     }
 
     if (err) {
@@ -71,15 +70,6 @@ function compileError(baseErrorMessage, err, response, body) {
     }
 
     return null;
-}
-
-function getAdditionalResponseMessage(response) {
-    switch(response.statusCode) {
-        case 401:
-            return 'Session is unauthorized';
-        default:
-            return 'No message';
-    }
 }
 
 module.exports = {

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -94,7 +94,7 @@ class Transport extends Events {
         }
         catch (err) {
             const error = new SDKError(`Error on WS ping: ${err.message}`, null, err);
-            this.emit('error', err);
+            this.emit('error', error);
         }
     }
 

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -271,7 +271,7 @@ describe('Agent SDK Tests', () => {
 
         // If:
         requestCSDSStub.yieldsAsync(new Error('cannot connect to csds'));
-        agent._handleRefreshSessionFlow((err) => {
+        agent.refreshSession((err) => {
             // Then:
             // Propagate CSDS error
             expect(err).to.be.instanceof(Error);
@@ -283,7 +283,7 @@ describe('Agent SDK Tests', () => {
             // Then:
             if (context && context.location) {
                 expect(context.location).to.be.oneOf(['RefreshSession#CSDS', 'Connect#Login']);
-                expect(context.location).to.not.equal('RefreshSession#Relogin');
+                expect(context.location).to.not.equal('RefreshSession#Relogin#WS');
                 expect(context.location).to.not.equal('RefreshSession#REST');
             }
         })
@@ -304,7 +304,7 @@ describe('Agent SDK Tests', () => {
 
 
         // If:
-        agent._handleRefreshSessionFlow((err) => {
+        agent.refreshSession((err) => {
             // Then:
             // Propagate refreshSession error
             expect(err).to.be.instanceof(Error);
@@ -317,7 +317,7 @@ describe('Agent SDK Tests', () => {
             if (context && context.location) {
                 expect(context.location).to.equal('RefreshSession#REST');
                 expect(context.location).to.not.equal('RefreshSession#CSDS');
-                expect(context.location).to.not.equal('RefreshSession#Relogin');
+                expect(context.location).to.not.equal('RefreshSession#Relogin#WS');
             }
         })
     });
@@ -337,7 +337,7 @@ describe('Agent SDK Tests', () => {
         });
 
         // If:
-        agent._handleRefreshSessionFlow((err) => {
+        agent.refreshSession((err) => {
             // Then:
             // Should be successful with re-login
             expect(err).to.equal(null);
@@ -349,7 +349,7 @@ describe('Agent SDK Tests', () => {
                 // Then:
                 expect(context.location).to.equal('RefreshSession#REST');
                 expect(context.location).to.not.equal('RefreshSession#CSDS');
-                expect(context.location).to.not.equal('RefreshSession#Relogin');
+                expect(context.location).to.not.equal('RefreshSession#Relogin#WS');
             }
         })
     });
@@ -370,7 +370,7 @@ describe('Agent SDK Tests', () => {
 
 
         // Then:
-        agent._handleRefreshSessionFlow((err) => {
+        agent.refreshSession((err) => {
             // Should be successful with re-login
             expect(err).to.be.instanceof(Error);
             expect(err.message).to.equal('Failed to login');
@@ -379,7 +379,7 @@ describe('Agent SDK Tests', () => {
 
         agent.on('error', (error, context) => {
             if (context && context.location) {
-                expect(context.location).to.be.oneOf(['Connect#Login', 'RefreshSession#Relogin', 'RefreshSession#REST'])
+                expect(context.location).to.be.oneOf(['Connect#Login', 'RefreshSession#Relogin#WS', 'RefreshSession#REST'])
                 expect(context.location).to.not.equal('RefreshSession#CSDS');
             }
         })
@@ -398,7 +398,7 @@ describe('Agent SDK Tests', () => {
         });
 
         // If:
-        agent._handleRefreshSessionFlow((err) => {
+        agent.refreshSession((err) => {
             // Then:
             // Successful handleRefreshSessionFlow
             expect(err).to.equal(null);
@@ -407,7 +407,7 @@ describe('Agent SDK Tests', () => {
 
         agent.on('success', (context) => {
             if (context && context.location) {
-                expect(context.location).to.be.oneOf(['Connect#Login', 'RefreshSession#Relogin', 'RefreshSession#REST', 'RefreshSession#CSDS']);
+                expect(context.location).to.be.oneOf(['Connect#Login', 'RefreshSession#Relogin#WS', 'RefreshSession#REST', 'RefreshSession#CSDS']);
             }
         })
     });

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -31,11 +31,16 @@ describe('Agent SDK Tests', () => {
         class Transport extends Events {
             constructor(conf) {
                 super();
+                this.configuration = { token: null };
                 this.send = tranportSendStub;
 
                 setImmediate(() => {
                     this.emit('open', conf);
                 });
+            }
+
+            reconnect() {
+
             }
 
             close() {
@@ -277,7 +282,7 @@ describe('Agent SDK Tests', () => {
         agent.on('error', (error, context) => {
             // Then:
             if (context && context.location) {
-                expect(context.location).to.equal('RefreshSession#CSDS');
+                expect(context.location).to.be.oneOf(['RefreshSession#CSDS', 'Connect#Login']);
                 expect(context.location).to.not.equal('RefreshSession#Relogin');
                 expect(context.location).to.not.equal('RefreshSession#REST');
             }
@@ -374,7 +379,7 @@ describe('Agent SDK Tests', () => {
 
         agent.on('error', (error, context) => {
             if (context && context.location) {
-                expect(context.location).to.be.oneOf(['RefreshSession#Relogin', 'RefreshSession#REST'])
+                expect(context.location).to.be.oneOf(['Connect#Login', 'RefreshSession#Relogin', 'RefreshSession#REST'])
                 expect(context.location).to.not.equal('RefreshSession#CSDS');
             }
         })
@@ -402,7 +407,7 @@ describe('Agent SDK Tests', () => {
 
         agent.on('success', (context) => {
             if (context && context.location) {
-                expect(context.location).to.be.oneOf(['RefreshSession#Relogin', 'RefreshSession#REST', 'RefreshSession#CSDS']);
+                expect(context.location).to.be.oneOf(['Connect#Login', 'RefreshSession#Relogin', 'RefreshSession#REST', 'RefreshSession#CSDS']);
             }
         })
     });

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -351,6 +351,7 @@ describe('Agent SDK Tests', () => {
                 // Propagate CSDS error
                 expect(err).to.be.instanceof(Error);
                 expect(err.message).to.equal('Error on CSDS request: cannot connect to csds');
+                agent.dispose();
                 done();
             });
         });
@@ -383,6 +384,7 @@ describe('Agent SDK Tests', () => {
                 // Propagate refreshSession error
                 expect(err).to.be.instanceof(Error);
                 expect(err.message).to.equal('Failed to connect to agentVEP');
+                agent.dispose();
                 done();
             });
         });
@@ -417,6 +419,7 @@ describe('Agent SDK Tests', () => {
                 // Then:
                 // Should be successful with re-login
                 expect(err).to.equal(null);
+                agent.dispose();
                 done();
             });
         });
@@ -453,6 +456,7 @@ describe('Agent SDK Tests', () => {
                 // Should be successful with re-login
                 expect(err).to.be.instanceof(Error);
                 expect(err.message).to.equal('Failed to login');
+                agent.dispose();
                 done();
             });
         });
@@ -483,6 +487,7 @@ describe('Agent SDK Tests', () => {
                 // Then:
                 // Successful handleRefreshSessionFlow
                 expect(err).to.equal(null);
+                agent.dispose();
                 done();
             });
         });
@@ -512,7 +517,8 @@ describe('Agent SDK Tests', () => {
                 // Then:
                 // Successful handleRefreshSessionFlow
                 expect(err).to.be.instanceOf(Error);
-                expect(err.message).to.equal('CSRF and JAR are not defined for this agent. Please reconnect with bearer token');
+                expect(err.message).to.equal('CSRF and JAR are not defined for this agent. Please reconnect with bearer token.');
+                agent.dispose();
                 done();
             });
         });

--- a/test/agent_sdk_test.js
+++ b/test/agent_sdk_test.js
@@ -83,6 +83,23 @@ describe('Agent SDK Tests', () => {
         });
     });
 
+    it('getBearerToken: should be able to get a token after agent is connected', done => {
+        requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
+        const loginData = {bearer: 'im encrypted', csrf: 'someCsrf', config: {userId: 'imauser'}};
+        externalServices.login.yieldsAsync(null, loginData);
+        externalServices.getAgentId.yieldsAsync(null, {pid: 'someId'});
+        const agent = new Agent({
+            accountId: 'account',
+            username: 'me',
+            password: 'password'
+        });
+        agent.on('connected', () => {
+            expect(agent.getBearerToken()).to.equal(loginData.bearer);
+            agent.dispose();
+            done();
+        });
+    });
+
     it('should emit an error if userId is undefined', done => {
         requestCSDSStub.yieldsAsync(null, {}, csdsResponse);
         externalServices.login.yieldsAsync(null, {bearer: 'im encrypted', config: {}, accountData:'NO'});

--- a/test/external_services_test.js
+++ b/test/external_services_test.js
@@ -1,0 +1,62 @@
+'use strict';
+const expect = require('chai').expect;
+const external = require('../lib/ExternalServices');
+
+describe('External Services', () => {
+    it('compileError: get SDKError from response', (done) => {
+        const response = {
+            statusMessage: 'Unauthorized',
+            statusCode: 401
+        };
+
+        const baseMesage = 'Some error';
+
+        const error = external.compileError(baseMesage, null, response, null);
+        expect(error.code).to.equal(response.statusCode);
+        expect(error.message).to.equal(`${baseMesage}: ${response.statusMessage}`);
+        done();
+    });
+
+    it('compileError: get SDKError from body', (done) => {
+        const body = {
+            error: {
+                statusMessage: 'Unauthorized',
+                internalCode: 401
+            }
+        };
+
+        const baseMesage = 'Some error';
+
+        const error = external.compileError(baseMesage, null, null, body);
+        expect(error.code).to.equal(body.error.internalCode);
+        expect(error.message).to.equal(`${baseMesage}: ${JSON.stringify(body.error)}`);
+        done();
+    });
+
+    it('compileError: get SDKError from error', (done) => {
+        const error = new Error('Some error');
+
+        const baseMesage = 'Some error';
+
+        const actualError = external.compileError(baseMesage, error, null, null);
+        expect(actualError.code).to.equal(null);
+        expect(actualError.message).to.equal(`${baseMesage}: ${error.message}`);
+        expect(actualError.error).to.equal(error);
+        done();
+    });
+
+    it('compileError: when no condition is met', (done) => {
+        const response = {
+            statusMessage: 'Unauthorized',
+            statusCode: 201
+        };
+        const body = {
+            message: 'some body'
+        };
+        const baseMesage = 'Some error';
+
+        const actualError = external.compileError(baseMesage, null, response, body);
+        expect(actualError).to.equal(null);
+        done();
+    })
+});


### PR DESCRIPTION
* Refactor the refreshSession function to be resilient to network failures, and handles unauthorized error appropriately: re-login and re-connect WS

* Emits error and success events on possible failure points (especially on refreshSession)

* Exposes public interfaces to let clients use existing functions

* Unit tests on the refreshSession flow