### PR TITLE
Added disable refresh session config

### DIFF
--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -58,6 +58,8 @@ class SDK extends Events {
     constructor(conf) {
         super();
 
+        this._setDefaultConfigurations(conf);
+
         // verify that an accountId is present
         if (!conf.accountId) {
             throw new Error('missing accountId param');
@@ -81,6 +83,11 @@ class SDK extends Events {
 
         // connect
         this.connect(() => {});
+    }
+
+    _setDefaultConfigurations(conf) {
+        // Set true as the default value
+        conf.disablePeriodicRefreshSession = conf.disablePeriodicRefreshSession !== false;
     }
 
     /**************************************************
@@ -177,6 +184,10 @@ class SDK extends Events {
     startPeriodicRefreshSession() {
         // Cancel all refresh session
         clearTimeout(this.refreshSessionTimeoutId);
+
+        if (this.conf.disablePeriodicRefreshSession) {
+            return;
+        }
 
         // Start periodic call
         this.refreshSessionTimeoutId = setTimeout(() => {


### PR DESCRIPTION
There are instances where an agent is logged in from multiple instances. We should add a capability to disable the periodic refresh session call to avoid these instances to log each other out.