### PR TITLE
added support for checking  custom domain type for web socket connection

### DIFF
--- a/lib/AgentSDK.js
+++ b/lib/AgentSDK.js
@@ -110,8 +110,11 @@ class SDK extends Events {
             }
 
             // 3. init
+            
+            // Checking if any valid web socket domain type is passed in config else facadeMsg is default type.
+            const wsDomain = this.conf.wsDomainType && domains[this.conf.wsDomainType] ? domains[this.conf.wsDomainType]: domains.facadeMsg;
             this._init(Object.assign({
-                domain: domains.facadeMsg,
+                domain: wsDomain,
                 token: token
             }, this.conf));
 
@@ -242,8 +245,11 @@ class SDK extends Events {
                 callback(null);
             } else {
                 // 3. init
+                
+                // Checking if any valid web socket domain type is passed in config else facadeMsg is default type.
+                const wsDomain = this.conf.wsDomainType && domains[this.conf.wsDomainType] ? domains[this.conf.wsDomainType]: domains.facadeMsg;
                 this._init(Object.assign({
-                    domain: domains.facadeMsg,
+                    domain: wsDomain,
                     token: token
                 }, this.conf));
                 callback(null);


### PR DESCRIPTION
Added an option to get domain type from conf for web socket connection. 
By default it is facadeMsg and can be overridden by sending valid domain type in 'wsDomainType' key of conf.